### PR TITLE
Filter audio feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ AZURE_OPENAI_ENDPOINT=fill-me-in
 
 PROPEL_AUTH_ENDPOINT=fill-me-in
 PROPEL_AUTH_API_KEY=fill-me-in
+
+HF_AUTH_TOKEN=fill-me-in

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -146,8 +146,8 @@ class ResponseAgent:
         loop = asyncio.get_running_loop()
 
         rec_time = time()
-        wavfile.write(f"{rec_time}_before.wav", 16000, audio_data)
-        np.save(f"{rec_time}_audio_data.npy", audio_data)
+        # wavfile.write(f"{rec_time}_before.wav", 16000, audio_data)
+        # np.save(f"{rec_time}_audio_data.npy", audio_data)
         audio_data = segment_audio(
             audio_data=audio_data,
             sample_rate=16000,
@@ -156,7 +156,7 @@ class ResponseAgent:
             inference=inference,
         )
         
-        wavfile.write(f"{rec_time}_after.wav", 16000, audio_data)
+        # wavfile.write(f"{rec_time}_after.wav", 16000, audio_data)
         t0 = time()
 
         print("RUNNING TRANSCRIBE IN EXECUTOR")

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -147,7 +147,6 @@ class ResponseAgent:
 
         rec_time = time()
         # wavfile.write(f"{rec_time}_before.wav", 16000, audio_data)
-        # np.save(f"{rec_time}_audio_data.npy", audio_data)
         audio_data = segment_audio(
             audio_data=audio_data,
             sample_rate=16000,

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -5,6 +5,7 @@ from tempfile import NamedTemporaryFile
 from time import time
 from typing import Optional
 import wave
+import requests 
 
 # NOTE(zach): On Mac OS, the first import fails, but the subsequent one
 # succeeds. /shrug.
@@ -27,12 +28,23 @@ from openduck_py.db import get_db_async, AsyncSession
 from openduck_py.prompts import prompt
 from openduck_py.voices import styletts2
 from openduck_py.routers.templates import generate
+from openduck_py.utils.speaker_identification import segment_audio, load_pipelines
+
+pipeline, inference = load_pipelines()
+
+with open("aec-cartoon-degraded.wav", "wb") as f:
+    f.write(
+        requests.get(
+            "https://s3.us-west-2.amazonaws.com/quack.uberduck.ai/aec-cartoon-degraded.wav"
+        ).content
+    )
+
+speaker_embedding = inference("aec-cartoon-degraded.wav")
 
 asr_model = asr_models.EncDecCTCModelBPE.from_pretrained(
     model_name="nvidia/stt_en_fastconformer_ctc_large"
 )
 normalizer = Normalizer(input_case="cased", lang="en")
-
 audio_router = APIRouter(prefix="/audio")
 
 
@@ -132,6 +144,21 @@ class ResponseAgent:
             return audio_chunk_bytes
 
         loop = asyncio.get_running_loop()
+
+        rec_time = time()
+        wavfile.write(f"{rec_time}_before.wav", 16000, audio_data)
+        print(f"Audio data shape before: {audio_data.shape}")
+
+        np.save(f"{rec_time}_audio_data.npy", audio_data)
+        audio_data = segment_audio(
+            audio_data=audio_data,
+            sample_rate=16000,
+            speaker_embedding=speaker_embedding,
+            pipeline=pipeline,
+            inference=inference,
+        )
+        print(f"Audio data shape after: {audio_data.shape}")
+        wavfile.write(f"{rec_time}_after.wav", 16000, audio_data)
 
         t0 = time()
 

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -163,7 +163,7 @@ class ResponseAgent:
         print("transcription", transcription)
 
         if not transcription:
-            return 
+            return
 
         t_whisper = time()
 

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -145,8 +145,6 @@ class ResponseAgent:
 
         loop = asyncio.get_running_loop()
 
-        rec_time = time()
-        # wavfile.write(f"{rec_time}_before.wav", 16000, audio_data)
         audio_data = segment_audio(
             audio_data=audio_data,
             sample_rate=16000,
@@ -155,7 +153,6 @@ class ResponseAgent:
             inference=inference,
         )
         
-        # wavfile.write(f"{rec_time}_after.wav", 16000, audio_data)
         t0 = time()
 
         print("RUNNING TRANSCRIBE IN EXECUTOR")

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -147,8 +147,6 @@ class ResponseAgent:
 
         rec_time = time()
         wavfile.write(f"{rec_time}_before.wav", 16000, audio_data)
-        print(f"Audio data shape before: {audio_data.shape}")
-
         np.save(f"{rec_time}_audio_data.npy", audio_data)
         audio_data = segment_audio(
             audio_data=audio_data,
@@ -157,9 +155,8 @@ class ResponseAgent:
             pipeline=pipeline,
             inference=inference,
         )
-        print(f"Audio data shape after: {audio_data.shape}")
+        
         wavfile.write(f"{rec_time}_after.wav", 16000, audio_data)
-
         t0 = time()
 
         print("RUNNING TRANSCRIBE IN EXECUTOR")
@@ -167,7 +164,7 @@ class ResponseAgent:
         print("transcription", transcription)
 
         if not transcription:
-            return
+            return 
 
         t_whisper = time()
 

--- a/openduck-py/openduck_py/utils/speaker_identification.py
+++ b/openduck-py/openduck_py/utils/speaker_identification.py
@@ -1,6 +1,6 @@
 import time
 import os
-from typing import Dict
+from typing import Dict, List
 
 import torch
 import numpy as np
@@ -98,14 +98,6 @@ def filter_voices(d: dict, threshold: float = 0.5):
             new_d[k] = new_v
     return new_d
 
-
-import numpy as np
-import torch
-from typing import List
-
-
-import numpy as np
-import torch
 
 
 def segment_audio(

--- a/openduck-py/openduck_py/utils/speaker_identification.py
+++ b/openduck-py/openduck_py/utils/speaker_identification.py
@@ -41,7 +41,6 @@ def identify_speakers(
         speaker_embedding (np.array): The speaker embedding to compare against.
         pipeline (Pipeline): The diarization pipeline.
         inference (Inference): The embedding inference pipeline.
-        filename (str): The filename of the input file.
 
     Returns:
         Dict: The segments and their distances from the speaker embedding.

--- a/openduck-py/openduck_py/utils/speaker_identification.py
+++ b/openduck-py/openduck_py/utils/speaker_identification.py
@@ -1,9 +1,13 @@
+import time
+import os
+from typing import Dict
+
 import torch
 import numpy as np
-from pyannote.audio import Pipeline, Inference, Model
 from scipy.spatial.distance import cdist
-from typing import Dict
-import os
+from pyannote.core import Segment
+from pyannote.audio import Pipeline, Inference, Model
+
 
 HF_AUTH_TOKEN = os.getenv("HF_AUTH_TOKEN")
 
@@ -27,35 +31,107 @@ def load_pipelines() -> tuple:
     return pipeline, inference
 
 
+# def identify_speakers(
+#     audio_data: torch.Tensor,
+#     sample_rate: int,
+#     speaker_embedding: np.array,
+#     pipeline: Pipeline,
+#     inference: Inference,
+# ) -> Dict:
+#     """
+#     Segment the speaker in the input file and return the segments and their distances from the speaker embedding.
+
+#     Args:
+#         input_filename (str): The input file to segment.
+#         speaker_embedding (np.array): The speaker embedding to compare against.
+#         pipeline (Pipeline): The diarization pipeline.
+#         inference (Inference): The embedding inference pipeline.
+
+#     Returns:
+#         Dict: The segments and their distances from the speaker embedding.
+
+#     """
+#     # NOTE(wrl): Diarization takes about 25x longer than inference (0.62 seconds vs 0.024 seconds). Can we only run
+#     # the inference on 1 second chunks?
+#     speaker_segments = {}
+#     start = time.time()
+#     pyannote_input = {"waveform": audio_data, "sample_rate": sample_rate}
+#     output = pipeline(pyannote_input)
+#     print(f"Speaker diarization took {time.time() - start:.3f} seconds")
+#     for segment, _, speaker in output.itertracks(yield_label=True):
+#         start = time.time()
+#         print(f"Shape of audio data: {audio_data.shape}")
+#         print(f"Segment: {segment.start} - {segment.end}")
+#         print(
+#             f"length of audio data: {len(audio_data[1])} and sample rate: {sample_rate} so duration is {len(audio_data) / sample_rate}"
+#         )
+#         segment_embedding = inference.crop(pyannote_input, segment)
+#         print(f"Embedding inference took {time.time() - start:.3f} seconds")
+#         distance = cdist([segment_embedding], [speaker_embedding], metric="cosine")[
+#             0, 0
+#         ]
+#         if speaker not in speaker_segments:
+#             speaker_segments[speaker] = {"times": [], "distances": []}
+#         speaker_segments[speaker]["times"].append((segment.start, segment.end))
+#         speaker_segments[speaker]["distances"].append(distance)
+
+#     return speaker_segments
+
+
 def identify_speakers(
-    input_filename: str,
+    audio_data: torch.Tensor,
+    sample_rate: int,
     speaker_embedding: np.array,
-    pipeline: Pipeline,
-    inference: Inference,
+    pipeline,
+    inference,
 ) -> Dict:
     """
     Segment the speaker in the input file and return the segments and their distances from the speaker embedding.
 
     Args:
-        input_filename (str): The input file to segment.
+        audio_data (torch.Tensor): The waveform of the input audio.
+        sample_rate (int): The sample rate of the input audio.
         speaker_embedding (np.array): The speaker embedding to compare against.
-        pipeline (Pipeline): The diarization pipeline.
-        inference (Inference): The embedding inference pipeline.
+        pipeline: The diarization pipeline.
+        inference: The embedding inference pipeline.
 
     Returns:
         Dict: The segments and their distances from the speaker embedding.
-
     """
     speaker_segments = {}
-    output = pipeline(input_filename)
+    start = time.time()
+    pyannote_input = {"waveform": audio_data, "sample_rate": sample_rate}
+    output = pipeline(pyannote_input)
+    print()
+    print(f"Speaker diarization took {time.time() - start:.3f} seconds")
+
+    audio_length_seconds = (
+        audio_data.shape[1] / sample_rate
+    )  # Corrected to use the second dimension of audio_data
+
     for segment, _, speaker in output.itertracks(yield_label=True):
-        segment_embedding = inference.crop(filename, segment)
+        # Boundary check for the segment
+        segment_end = min(segment.end, audio_length_seconds)
+        if segment.start >= segment_end or segment.end - segment.start < 0.3:
+            continue  # Skip segments that are out of bounds or have no duration
+
+        start = time.time()
+        print(f"Shape of audio data: {audio_data.shape}")
+        print(f"Segment: {segment.start} - {segment_end}")
+        print(
+            f"Length of audio data: {audio_data.shape[1]} samples and sample rate: {sample_rate} so duration is {audio_length_seconds} seconds"
+        )
+        adjusted_segment = Segment(segment.start, segment_end)
+
+        segment_embedding = inference.crop(pyannote_input, adjusted_segment)
+        print(f"Embedding inference took {time.time() - start:.3f} seconds")
+
         distance = cdist([segment_embedding], [speaker_embedding], metric="cosine")[
             0, 0
         ]
         if speaker not in speaker_segments:
             speaker_segments[speaker] = {"times": [], "distances": []}
-        speaker_segments[speaker]["times"].append((segment.start, segment.end))
+        speaker_segments[speaker]["times"].append((segment.start, segment_end))
         speaker_segments[speaker]["distances"].append(distance)
 
     return speaker_segments
@@ -78,17 +154,102 @@ def filter_voices(d: dict, threshold: float = 0.5):
     return new_d
 
 
-if __name__ == "__main__":
-    from pprint import pprint
+import numpy as np
+import torch
+from typing import List
 
-    filename = "../../../samples/speaker-seg-test.wav"
-    pipeline, inference = load_pipelines()
-    speaker_embedding = inference("../../../samples/aec-cartoon.wav")
+
+import numpy as np
+import torch
+
+
+def segment_audio(
+    audio_data: np.array,
+    sample_rate: int,
+    speaker_embedding: np.array,
+    pipeline,
+    inference,
+) -> np.array:
+
+    # converts to [1, n] shape if not already
+    # audio_data = audio_data.reshape(1, -1) if len(audio_data.shape) == 1 else audio_data
+    audio_data_tensor = torch.tensor(audio_data).unsqueeze(0)
+    # Identify speakers
+    start = time.time()
     speaker_segments = identify_speakers(
-        filename, speaker_embedding, pipeline, inference
+        audio_data=audio_data_tensor,
+        sample_rate=sample_rate,
+        speaker_embedding=speaker_embedding,
+        pipeline=pipeline,
+        inference=inference,
     )
+    print(f"Speaker identification took {time.time() - start:.3f} seconds")
 
-    pprint(speaker_segments, width=1)
-
+    # Filter identified speaker segments
+    start = time.time()
     speaker_segments = filter_voices(speaker_segments)
-    pprint(speaker_segments, width=1)
+    print(f"Speaker filtering took {time.time() - start:.3f} seconds")
+    BUFFER = 0.1  # seconds
+    concatenated_audio_data = np.array([], dtype=np.float32)
+
+    start_time = time.time()
+    for speaker, data in speaker_segments.items():
+        for start, end in data["times"]:
+            start = max(0, start - BUFFER)
+            end = min(len(audio_data) / sample_rate, end + BUFFER)
+            segment = audio_data[int(start * sample_rate) : int(end * sample_rate)]
+            print(f"Audio data shape: {audio_data.shape}")
+            print(f"Segment shape: {segment.shape}")
+            print(f"Concatenated audio shape: {concatenated_audio_data.shape}")
+            concatenated_audio_data = np.concatenate((concatenated_audio_data, segment))
+
+    print(f"Audio concatenation took {time.time() - start_time:.3f} seconds")
+    return concatenated_audio_data
+
+
+if __name__ == "__main__":
+    # print(speaker_embedding)
+    # from pprint import pprint
+    # import librosa
+
+    # filename = "../../../samples/speaker-seg-test.wav"
+    pipeline, inference = load_pipelines()
+    # speaker_embedding = inference("../../../samples/aec-cartoon.wav")
+    # # speaker_embedding
+    # librosa_audio, sr = librosa.load(filename, sr=16000)
+    # # # speaker_segments = identify_speakers(
+    # # #     audio_data=librosa_audio,
+    # # #     sample_rate=sr,
+    # # #     speaker_embedding=speaker_embedding,
+    # # #     pipeline=pipeline,
+    # # #     inference=inference,
+    # # # )
+
+    # # # pprint(speaker_segments, width=1)
+
+    # # # speaker_segments = filter_voices(speaker_segments)
+    # # # pprint(speaker_segments, width=1)
+
+    # filtered_audio_data = segment_audio(
+    #     audio_data=librosa_audio,
+    #     sample_rate=sr,
+    #     speaker_embedding=speaker_embedding,
+    #     pipeline=pipeline,
+    #     inference=inference,
+    # )
+    # # # convert to wavfile and write to filtered.wav
+
+    # from scipy.io.wavfile import write
+
+    # write("filtered2.wav", sr, filtered_audio_data)
+
+    #
+    audio_data = np.load('../../1708722359.8986475_audio_data.npy')
+    audio_data = torch.tensor(audio_data).view(1, -1)
+    input = {"waveform": audio_data, "sample_rate": 16000}
+    
+    for i in range(150, 120, -1):
+        end_time = i / 100
+        print(f"Testing end time: {end_time}")
+        inference.crop(input, Segment(1,end_time))
+    # inference.crop(input, Segment(1,1.35))

--- a/openduck-py/openduck_py/utils/speaker_identification.py
+++ b/openduck-py/openduck_py/utils/speaker_identification.py
@@ -1,0 +1,95 @@
+import torch
+import numpy as np
+from pyannote.audio import Pipeline, Inference, Model
+from scipy.spatial.distance import cdist
+from typing import Dict
+import os
+
+HF_AUTH_TOKEN = os.getenv("HF_AUTH_TOKEN")
+
+
+def load_pipelines() -> tuple:
+    """
+    Load the diarization and embedding pipelines.
+    """
+    pipeline = Pipeline.from_pretrained(
+        "pyannote/speaker-diarization-3.1",
+        use_auth_token=HF_AUTH_TOKEN,
+    )
+    pipeline.to(torch.device("cuda"))
+
+    embedding_pipeline = Model.from_pretrained(
+        "pyannote/embedding", use_auth_token=HF_AUTH_TOKEN
+    )
+    inference = Inference(embedding_pipeline, window="whole")
+    inference.to(torch.device("cuda"))
+
+    return pipeline, inference
+
+
+def identify_speakers(
+    input_filename: str,
+    speaker_embedding: np.array,
+    pipeline: Pipeline,
+    inference: Inference,
+) -> Dict:
+    """
+    Segment the speaker in the input file and return the segments and their distances from the speaker embedding.
+
+    Args:
+        input_filename (str): The input file to segment.
+        speaker_embedding (np.array): The speaker embedding to compare against.
+        pipeline (Pipeline): The diarization pipeline.
+        inference (Inference): The embedding inference pipeline.
+        filename (str): The filename of the input file.
+
+    Returns:
+        Dict: The segments and their distances from the speaker embedding.
+
+    """
+    speaker_segments = {}
+    output = pipeline(input_filename)
+    for segment, _, speaker in output.itertracks(yield_label=True):
+        segment_embedding = inference.crop(filename, segment)
+        distance = cdist([segment_embedding], [speaker_embedding], metric="cosine")[
+            0, 0
+        ]
+        if speaker not in speaker_segments:
+            speaker_segments[speaker] = {"times": [], "distances": []}
+        speaker_segments[speaker]["times"].append((segment.start, segment.end))
+        speaker_segments[speaker]["distances"].append(distance)
+
+    return speaker_segments
+
+
+def filter_voices(d: dict, threshold: float = 0.5):
+    """
+    This filters out the voices that are below the threshold because
+    that indicates that it is our own TTS voice.
+    """
+    new_d = {}
+    for k, v in d.items():
+        new_v = {"times": [], "distances": []}
+        for i, dist in enumerate(v["distances"]):
+            if dist > threshold:
+                new_v["times"].append(v["times"][i])
+                new_v["distances"].append(dist)
+        if new_v["times"]:
+            new_d[k] = new_v
+    return new_d
+
+
+if __name__ == "__main__":
+    from pprint import pprint
+
+    filename = "../../../samples/speaker-seg-test.wav"
+    pipeline, inference = load_pipelines()
+    speaker_embedding = inference("../../../samples/aec-cartoon.wav")
+    speaker_segments = identify_speakers(
+        filename, speaker_embedding, pipeline, inference
+    )
+
+    pprint(speaker_segments, width=1)
+
+    speaker_segments = filter_voices(speaker_segments)
+    pprint(speaker_segments, width=1)

--- a/openduck-py/openduck_py/utils/speaker_identification.py
+++ b/openduck-py/openduck_py/utils/speaker_identification.py
@@ -58,13 +58,12 @@ def identify_speakers(
 
     audio_length_seconds = (
         audio_data.shape[1] / sample_rate
-    )  # Corrected to use the second dimension of audio_data
+    ) 
 
     for segment, _, speaker in output.itertracks(yield_label=True):
-        # Boundary check for the segment
         segment_end = min(segment.end, audio_length_seconds)
         if segment.start >= segment_end or segment.end - segment.start < 0.3:
-            continue  # Skip segments that are out of bounds or have no duration
+            continue  
 
         start = time.time()
         adjusted_segment = Segment(segment.start, segment_end)
@@ -117,10 +116,7 @@ def segment_audio(
     inference,
 ) -> np.array:
 
-    # converts to [1, n] shape if not already
-    # audio_data = audio_data.reshape(1, -1) if len(audio_data.shape) == 1 else audio_data
     audio_data_tensor = torch.tensor(audio_data).unsqueeze(0)
-    # Identify speakers
     start = time.time()
     speaker_segments = identify_speakers(
         audio_data=audio_data_tensor,
@@ -131,7 +127,6 @@ def segment_audio(
     )
     print(f"[SEGMENTATION] Speaker identification took {time.time() - start:.3f} seconds")
 
-    # Filter identified speaker segments
     start = time.time()
     speaker_segments = filter_voices(speaker_segments)
     BUFFER = 0.1  # seconds

--- a/openduck-py/openduck_py/utils/speaker_identification.py
+++ b/openduck-py/openduck_py/utils/speaker_identification.py
@@ -30,54 +30,6 @@ def load_pipelines() -> tuple:
 
     return pipeline, inference
 
-
-# def identify_speakers(
-#     audio_data: torch.Tensor,
-#     sample_rate: int,
-#     speaker_embedding: np.array,
-#     pipeline: Pipeline,
-#     inference: Inference,
-# ) -> Dict:
-#     """
-#     Segment the speaker in the input file and return the segments and their distances from the speaker embedding.
-
-#     Args:
-#         input_filename (str): The input file to segment.
-#         speaker_embedding (np.array): The speaker embedding to compare against.
-#         pipeline (Pipeline): The diarization pipeline.
-#         inference (Inference): The embedding inference pipeline.
-
-#     Returns:
-#         Dict: The segments and their distances from the speaker embedding.
-
-#     """
-#     # NOTE(wrl): Diarization takes about 25x longer than inference (0.62 seconds vs 0.024 seconds). Can we only run
-#     # the inference on 1 second chunks?
-#     speaker_segments = {}
-#     start = time.time()
-#     pyannote_input = {"waveform": audio_data, "sample_rate": sample_rate}
-#     output = pipeline(pyannote_input)
-#     print(f"Speaker diarization took {time.time() - start:.3f} seconds")
-#     for segment, _, speaker in output.itertracks(yield_label=True):
-#         start = time.time()
-#         print(f"Shape of audio data: {audio_data.shape}")
-#         print(f"Segment: {segment.start} - {segment.end}")
-#         print(
-#             f"length of audio data: {len(audio_data[1])} and sample rate: {sample_rate} so duration is {len(audio_data) / sample_rate}"
-#         )
-#         segment_embedding = inference.crop(pyannote_input, segment)
-#         print(f"Embedding inference took {time.time() - start:.3f} seconds")
-#         distance = cdist([segment_embedding], [speaker_embedding], metric="cosine")[
-#             0, 0
-#         ]
-#         if speaker not in speaker_segments:
-#             speaker_segments[speaker] = {"times": [], "distances": []}
-#         speaker_segments[speaker]["times"].append((segment.start, segment.end))
-#         speaker_segments[speaker]["distances"].append(distance)
-
-#     return speaker_segments
-
-
 def identify_speakers(
     audio_data: torch.Tensor,
     sample_rate: int,
@@ -102,8 +54,7 @@ def identify_speakers(
     start = time.time()
     pyannote_input = {"waveform": audio_data, "sample_rate": sample_rate}
     output = pipeline(pyannote_input)
-    print()
-    print(f"Speaker diarization took {time.time() - start:.3f} seconds")
+    print(f"[SEGMENTATION] Speaker diarization took {time.time() - start:.3f} seconds")
 
     audio_length_seconds = (
         audio_data.shape[1] / sample_rate
@@ -116,15 +67,10 @@ def identify_speakers(
             continue  # Skip segments that are out of bounds or have no duration
 
         start = time.time()
-        print(f"Shape of audio data: {audio_data.shape}")
-        print(f"Segment: {segment.start} - {segment_end}")
-        print(
-            f"Length of audio data: {audio_data.shape[1]} samples and sample rate: {sample_rate} so duration is {audio_length_seconds} seconds"
-        )
         adjusted_segment = Segment(segment.start, segment_end)
 
         segment_embedding = inference.crop(pyannote_input, adjusted_segment)
-        print(f"Embedding inference took {time.time() - start:.3f} seconds")
+        print(f"[SEGMENTATION] Embedding inference took {time.time() - start:.3f} seconds")
 
         distance = cdist([segment_embedding], [speaker_embedding], metric="cosine")[
             0, 0
@@ -183,12 +129,11 @@ def segment_audio(
         pipeline=pipeline,
         inference=inference,
     )
-    print(f"Speaker identification took {time.time() - start:.3f} seconds")
+    print(f"[SEGMENTATION] Speaker identification took {time.time() - start:.3f} seconds")
 
     # Filter identified speaker segments
     start = time.time()
     speaker_segments = filter_voices(speaker_segments)
-    print(f"Speaker filtering took {time.time() - start:.3f} seconds")
     BUFFER = 0.1  # seconds
     concatenated_audio_data = np.array([], dtype=np.float32)
 
@@ -198,58 +143,7 @@ def segment_audio(
             start = max(0, start - BUFFER)
             end = min(len(audio_data) / sample_rate, end + BUFFER)
             segment = audio_data[int(start * sample_rate) : int(end * sample_rate)]
-            print(f"Audio data shape: {audio_data.shape}")
-            print(f"Segment shape: {segment.shape}")
-            print(f"Concatenated audio shape: {concatenated_audio_data.shape}")
             concatenated_audio_data = np.concatenate((concatenated_audio_data, segment))
 
-    print(f"Audio concatenation took {time.time() - start_time:.3f} seconds")
+    print(f"[SEGMENTATION] Audio concatenation took {time.time() - start_time:.3f} seconds")
     return concatenated_audio_data
-
-
-if __name__ == "__main__":
-    # print(speaker_embedding)
-    # from pprint import pprint
-    # import librosa
-
-    # filename = "../../../samples/speaker-seg-test.wav"
-    pipeline, inference = load_pipelines()
-    # speaker_embedding = inference("../../../samples/aec-cartoon.wav")
-    # # speaker_embedding
-    # librosa_audio, sr = librosa.load(filename, sr=16000)
-    # # # speaker_segments = identify_speakers(
-    # # #     audio_data=librosa_audio,
-    # # #     sample_rate=sr,
-    # # #     speaker_embedding=speaker_embedding,
-    # # #     pipeline=pipeline,
-    # # #     inference=inference,
-    # # # )
-
-    # # # pprint(speaker_segments, width=1)
-
-    # # # speaker_segments = filter_voices(speaker_segments)
-    # # # pprint(speaker_segments, width=1)
-
-    # filtered_audio_data = segment_audio(
-    #     audio_data=librosa_audio,
-    #     sample_rate=sr,
-    #     speaker_embedding=speaker_embedding,
-    #     pipeline=pipeline,
-    #     inference=inference,
-    # )
-    # # # convert to wavfile and write to filtered.wav
-
-    # from scipy.io.wavfile import write
-
-    # write("filtered2.wav", sr, filtered_audio_data)
-
-    #
-    audio_data = np.load('../../1708722359.8986475_audio_data.npy')
-    audio_data = torch.tensor(audio_data).view(1, -1)
-    input = {"waveform": audio_data, "sample_rate": 16000}
-    
-    for i in range(150, 120, -1):
-        end_time = i / 100
-        print(f"Testing end time: {end_time}")
-        inference.crop(input, Segment(1,end_time))
-    # inference.crop(input, Segment(1,1.35))


### PR DESCRIPTION
Filter TTS Voice out from audio. Uses pyannote speaker diarization and cosine similarity between embeddings to filter TTS voices.

This entire process takes 100-500 milliseconds but can be further optimized. 

Requires `HF_AUTH_TOKEN` to be set 