### PR TITLE
Output audio chunks to an asyncio Queue to decouple with websocket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM nvcr.io/nvidia/pytorch:24.01-py3
 ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /openduck-py
 
-# Copying is only necessary on prod, when you're not mounting the volume
-# COPY ./openduck-py /openduck-py
+COPY ./openduck-py /openduck-py
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -184,12 +184,10 @@ class ResponseAgent:
             classification_response_message = classification_response.choices[
                 0
             ].message.content
-            if (
-                classification_response_message == "stop"
-                or not transcription
-                or len(audio_data) < 100
-            ):
-                await self.response_queue.put(None)  # Signal to stop
+            if classification_response_message == "stop":
+                await self.response_queue.put(None)  # Signal to stop the conversation
+                return
+            if not transcription or len(audio_data) < 100:
                 return
 
             system_prompt = {

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -400,6 +400,6 @@ async def audio_response(
 
     # TODO(zach): We never actually close it right now, we wait for the client
     # to close. But we should close it based on some timeout.
-    await consumer_task.join()
+    await responder.response_queue.join()
     await websocket.close()
     await log_event(db, session_id, "ended_session")

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -398,8 +398,6 @@ async def audio_response(
         recorder.close_file()
         recorder.log()
 
-    # TODO(zach): We never actually close it right now, we wait for the client
-    # to close. But we should close it based on some timeout.
     await responder.response_queue.join()
     await websocket.close()
     await log_event(db, session_id, "ended_session")


### PR DESCRIPTION
Before, ResponseTask start_response() needed to be passed a websocket to send its output bytes. Instead, let's send the output bytes to an asyncio queue, and have a separate consumer worker which consumes audio chunks from the queue and sends them through the websocket, in a "producer-consumer" paradigm. (wow, cool word). This way it's easy to create a different consumer that sends it to WebRTC and is decoupled from the ResponseTask code. 