### PR TITLE
Streaming LLM output

### DIFF
--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -15,7 +15,7 @@ from sqlalchemy import select
 import torch
 from whisper import load_model
 from daily import *
-from litellm import completion
+from litellm import acompletion
 
 from openduck_py.models import DBChatHistory, DBChatRecord
 from openduck_py.models.chat_record import EventName
@@ -269,13 +269,13 @@ class ResponseAgent:
             messages = chat.history_json["messages"]
             messages.append(new_message)
 
-            response = await asyncio.to_thread(
-                completion, CHAT_MODEL, messages, temperature=0.3, stream=True
+            response = await acompletion(
+                CHAT_MODEL, messages, temperature=0.3, stream=True
             )
 
             complete_sentence = ""
             full_response = ""
-            for chunk in response:
+            async for chunk in response:
                 chunk_text = chunk.choices[0].delta.content
                 if not chunk_text:
                     break

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -281,7 +281,7 @@ class ResponseAgent:
                     break
                 complete_sentence += chunk_text
                 full_response += chunk_text
-                # TODO: Smarter sentence detection - this will fail on like Mr. Kennedy or whatever
+                # TODO: Smarter sentence detection - this will split sentences on cases like "Mr. Kennedy"
                 if re.search(r"(?<!\d)[.!?](?!\d)", chunk_text):
                     await self.speak_response(complete_sentence, db, t_whisper)
                     complete_sentence = ""


### PR DESCRIPTION
## **User description**
Streams 1 sentence at a time from the LLM and speaks the output. 

Currently the min latency for gpt-3.5-turbo is like 0.5-0.8 seconds. Now if the response is multiple seconds long, it will start talking once the first sentence is ready, without needing to wait for the other sentences as well. 

There's no async function for streaming chat completion, so I needed to wrap the sync function in an asyncio.to_thread(). 

Most of the line diffs here is because I moved code into a new function speak_response(), to process each sentence of response from the LLM.


___

## **Description**
- Implemented streaming of LLM output to start text-to-speech (TTS) synthesis as soon as the first sentence is ready, improving responsiveness.
- Created a new `speak_response` function to process and speak each sentence of the LLM response.
- Removed synchronous completion call and replaced it with an asynchronous thread to handle streaming.
- Removed redundant code by integrating the `_inference` function directly into the `speak_response` function.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>voice.py</strong><dd><code>Integrate Streaming LLM Output with TTS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openduck-py/openduck_py/routers/voice.py
<li>Replaced <code>acompletion</code> with <code>completion</code> and added streaming capability.<br> <li> Introduced <code>speak_response</code> function to handle speaking each sentence as <br>it's generated.<br> <li> Implemented streaming of LLM output to start speaking before the <br>entire response is ready.<br> <li> Removed the <code>_inference</code> function from <code>start_response</code> and integrated it <br>into <code>speak_response</code>.


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/65/files#diff-83ea5947a09005723a4450b92f794118b9e55099439455d9d9b4152c3ff0c4ce">+64/-55</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
