### PR TITLE
dedicated db path for volume mounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-openduck-py/test.db
+openduck-py/database/test.db
 .env.dev
 
 # Mac OS

--- a/openduck-py/openduck_py/db/__init__.py
+++ b/openduck-py/openduck_py/db/__init__.py
@@ -4,9 +4,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import configure_mappers, declarative_base, sessionmaker
 
 
-connection_string = f"sqlite:///{Path(__file__).parent.parent.parent}/test.db"
+connection_string = f"sqlite:///{Path(__file__).parent.parent.parent}/database/test.db"
 async_connection_string = (
-    f"sqlite+aiosqlite:///{Path(__file__).parent.parent.parent}/test.db"
+    f"sqlite+aiosqlite:///{Path(__file__).parent.parent.parent}/database/test.db"
 )
 
 


### PR DESCRIPTION
## **Description**
- Changed the SQLite connection string to point to a new `database` directory, which allows for better organization and volume mounting in containerized environments.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Update SQLite Connection String for Dedicated Database Directory</code></dd></summary>
<hr>

openduck-py/openduck_py/db/__init__.py
<li>Updated the SQLite connection string to use a dedicated <code>database</code> <br>directory.<br>


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/68/files#diff-e4212be6ec9dd1946c323374551cfaf8dc06fc8a6403faeb5d23794f68f89c70">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
