### PR TITLE
separate API for ML models

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,14 +21,28 @@ services:
     build: .
     command: >
       bash -c "python setup.py develop &&  \ 
-               mkdir -p models/styletts2 && \ 
-               aws s3 sync s3://uberduck-models-us-west-2/prototype/styletts2 models/styletts2 && \ 
                apt update && apt install -y python3-pip && \ 
                pip install watchdog[watchmedo] && \ 
                watchmedo auto-restart --directory=./openduck_py --pattern=*.py --recursive -- python openduck_py/routers/voice.py"
     working_dir: /openduck-py/openduck-py
     volumes:
       - .:/openduck-py
+    env_file:
+      - .env.dev
+    runtime: nvidia
+  ml:
+    image: 613148481050.dkr.ecr.us-west-2.amazonaws.com/openduck:latest
+    build: .
+    command: >
+      bash -c "python setup.py develop &&  \ 
+               mkdir -p models/styletts2 && \ 
+               aws s3 sync s3://uberduck-models-us-west-2/prototype/styletts2 models/styletts2 && \ 
+               uvicorn openduck_py.routers.ml:app --reload --host 0.0.0.0 --port 8001"
+    working_dir: /openduck-py/openduck-py
+    volumes:
+      - .:/openduck-py
+    ports:
+      - "8001:8001"
     env_file:
       - .env.dev
     runtime: nvidia

--- a/openduck-py/openduck_py/routers/ml.py
+++ b/openduck-py/openduck_py/routers/ml.py
@@ -47,20 +47,16 @@ async def text_to_speech(tts_input: TTSInput):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-app = FastAPI(
-    title="ML Services for OpenDuck", servers=[{"url": "http://localhost:8001"}]
-)
+app = FastAPI(title="ML Services for Openduck")
 
-# Add CORS middleware to allow requests from any origin
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # Allows all origins
+    allow_origins=["http://localhost:3000"],
     allow_credentials=True,
-    allow_methods=["*"],  # Allows all methods
-    allow_headers=["*"],  # Allows all headers
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
-# Include the ML router
 app.include_router(ml_router)
 
 

--- a/openduck-py/openduck_py/routers/ml.py
+++ b/openduck-py/openduck_py/routers/ml.py
@@ -1,0 +1,57 @@
+from fastapi import APIRouter, UploadFile, File, HTTPException
+from fastapi.responses import StreamingResponse
+import io
+
+ml_router = APIRouter(prefix="/ml")
+
+
+@ml_router.post("/transcribe")
+async def transcribe_audio(
+    audio: UploadFile = File(..., media_type="application/octet-stream")
+):
+    # Placeholder for actual audio transcription logic
+    try:
+        audio_data = await audio.read()
+        # Simulate transcription process
+        transcribed_text = "This is a simulated transcription."
+        return {"text": transcribed_text}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@ml_router.post("/tts")
+async def text_to_speech(text: str):
+    # Placeholder for actual TTS logic
+    try:
+        # Simulate TTS process
+        tts_audio = b"This is simulated TTS audio data."
+        return StreamingResponse(
+            io.BytesIO(tts_audio), media_type="application/octet-stream"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI(
+    title="ML Services for OpenDuck", servers=[{"url": "http://localhost:8001"}]
+)
+
+# Add CORS middleware to allow requests from any origin
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],  # Allows all origins
+    allow_credentials=True,
+    allow_methods=["*"],  # Allows all methods
+    allow_headers=["*"],  # Allows all headers
+)
+
+# Include the ML router
+app.include_router(ml_router)
+
+
+@app.get("/status")
+def status():
+    return dict(status="OK")

--- a/openduck-py/openduck_py/routers/ml.py
+++ b/openduck-py/openduck_py/routers/ml.py
@@ -6,13 +6,10 @@ ml_router = APIRouter(prefix="/ml")
 
 
 @ml_router.post("/transcribe")
-async def transcribe_audio(
-    audio: UploadFile = File(..., media_type="application/octet-stream")
-):
+async def transcribe_audio(audio: UploadFile = File(..., media_type="audio/wav")):
     # Placeholder for actual audio transcription logic
     try:
         audio_data = await audio.read()
-        # Simulate transcription process
         transcribed_text = "This is a simulated transcription."
         return {"text": transcribed_text}
     except Exception as e:

--- a/openduck-py/openduck_py/routers/ml.py
+++ b/openduck-py/openduck_py/routers/ml.py
@@ -1,10 +1,14 @@
 from fastapi import FastAPI, APIRouter, UploadFile, File, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 import io
 
 from whisper import load_model
 import numpy as np
+
+from openduck_py.voices.styletts2 import styletts2_inference
+from openduck_py.settings import OUTPUT_SAMPLE_RATE
 
 ml_router = APIRouter(prefix="/ml")
 
@@ -24,14 +28,20 @@ async def transcribe_audio(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+class TTSInput(BaseModel):
+    text: str
+
+
 @ml_router.post("/tts")
-async def text_to_speech(text: str):
-    # Placeholder for actual TTS logic
+async def text_to_speech(tts_input: TTSInput):
     try:
-        # Simulate TTS process
-        tts_audio = b"This is simulated TTS audio data."
+        audio_chunk = styletts2_inference(
+            text=tts_input.text,
+            output_sample_rate=OUTPUT_SAMPLE_RATE,
+        )
+        audio_chunk = np.int16(audio_chunk * 32767).tobytes()
         return StreamingResponse(
-            io.BytesIO(tts_audio), media_type="application/octet-stream"
+            io.BytesIO(audio_chunk), media_type="application/octet-stream"
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -181,7 +181,7 @@ class ResponseAgent:
 
     async def receive_audio(self, message: np.ndarray):
         # Convert the input audio from input_audio_format to float32
-        # The processing tools like VAD and Whisper expect float32
+        # Silero VAD and Whisper require float32
         if self.input_audio_format == "float32":
             audio_16k_np = np.frombuffer(message, dtype=np.float32)
         elif self.input_audio_format == "int32":

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -23,7 +23,6 @@ from openduck_py.models import DBChatHistory, DBChatRecord
 from openduck_py.models.chat_record import EventName
 from openduck_py.db import get_db_async, AsyncSession, SessionAsync
 from openduck_py.prompts import prompt
-from openduck_py.voices.styletts2 import STYLETTS2_SAMPLE_RATE
 from openduck_py.settings import (
     IS_DEV,
     WS_SAMPLE_RATE,
@@ -376,7 +375,7 @@ async def log_event(
 
         sample_rate = WS_SAMPLE_RATE
         if event == "generated_tts":
-            sample_rate = STYLETTS2_SAMPLE_RATE
+            sample_rate = OUTPUT_SAMPLE_RATE
         wavfile.write(abs_path, sample_rate, audio)
         print(f"Wrote wavfile to {abs_path}")
 


### PR DESCRIPTION
Since we will have multiple Daily processes, we need to separate out the GPU-intensive tasks into its own microservice. Otherwise, we would need to load a new copy of the ML models on the GPU for each process, which would overwhelm the GPU memory. 

This creates new endpoints `/ml/transcribe` and `/ml/tts` to perform Whisper transcription and StyleTTS2 inference. 