### PR TITLE
Deepgram streaming

### DIFF
--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -11,7 +11,7 @@ from litellm import acompletion
 from sqlalchemy import select
 import numpy as np
 import httpx
-from deepgram import DeepgramClient, PrerecordedOptions, FileSource
+from deepgram import DeepgramClient, LiveTranscriptionEvents, LiveOptions
 from scipy.io.wavfile import write
 
 from openduck_py.settings import (
@@ -20,8 +20,8 @@ from openduck_py.settings import (
     CHAT_MODEL_GPT4,
     LOG_TO_SLACK,
     ML_API_URL,
-    ASR_METHOD,
     DEEPGRAM_API_SECRET,
+    ASR_METHOD,
 )
 from openduck_py.configs.tts_config import TTSConfig
 from openduck_py.db import AsyncSession, SessionAsync
@@ -31,13 +31,10 @@ from openduck_py.logging.db import log_event
 from openduck_py.logging.slack import log_audio_to_slack
 from openduck_py.utils.third_party_tts import (
     aio_elevenlabs_tts,
-    ELEVENLABS_VIKRAM,
-    ELEVENLABS_CHRIS,
 )
 
 
-if ASR_METHOD == "deepgram":
-    deepgram = DeepgramClient(DEEPGRAM_API_SECRET)
+deepgram = DeepgramClient(DEEPGRAM_API_SECRET)
 
 
 async def _completion_with_retry(chat_model, messages):
@@ -237,7 +234,7 @@ class ResponseAgent:
             remote_path=f"recordings/{session_id}.wav",
         )
         self.vad = SileroVad()
-        # self.vad.init()
+        self.transcript = ""
         self.record = record
         self.time_of_last_activity = time()
         self.response_task: Optional[asyncio.Task] = None
@@ -253,6 +250,26 @@ class ResponseAgent:
         self.tts_config = tts_config
 
         self._time_of_last_record = None
+
+        self.dg_connection = deepgram.listen.live.v("1")
+        options = LiveOptions(
+            model="nova-2",
+            punctuate=True,
+            language="en-US",
+            encoding="linear16",
+            channels=1,
+            sample_rate=WS_SAMPLE_RATE,
+            # To get UtteranceEnd, the following must be set:
+            interim_results=True,
+            utterance_end_ms="1000",
+            vad_events=True,
+        )
+
+        self.dg_connection.on(
+            LiveTranscriptionEvents.Transcript,
+            lambda x, result, **kwargs: self.on_message(result),
+        )
+        self.dg_connection.start(options)
 
     def _reset_transcription(self):
         self.audio_data = []
@@ -271,6 +288,9 @@ class ResponseAgent:
         self.is_responding = False
 
     async def receive_audio(self, message: bytes):
+
+        self.dg_connection.send(message)
+
         # Convert the input audio from input_audio_format to float32
         # Silero VAD and Whisper require float32
         if self.input_audio_format == "float32":
@@ -292,6 +312,7 @@ class ResponseAgent:
                 print("TOOOOO SLOW: ", time() - self._time_of_last_record)
             self._time_of_last_record = time()
             self.recorder.append(audio_16k_np)
+
         i = 0
         while i < len(audio_16k_np):
             upper = i + self.vad.window_size
@@ -386,10 +407,7 @@ class ResponseAgent:
         chat.history_json["messages"] = messages
         await db.commit()
 
-    async def start_response(
-        self,
-        audio_data: List[np.ndarray],
-    ):
+    async def start_response(self, audio_data: List[np.ndarray]):
         audio_data = np.concatenate(audio_data)
         self.is_responding = True
         try:
@@ -399,7 +417,11 @@ class ResponseAgent:
                 )
                 t_0 = time()
 
-                transcription = await _transcribe(audio_data)
+                transcription = (
+                    self.transcript
+                    if ASR_METHOD == "deepgram"
+                    else await _transcribe(audio_data)
+                )
                 print("TRANSCRIPTION: ", transcription, flush=True)
                 t_whisper = time()
                 await log_event(
@@ -409,7 +431,7 @@ class ResponseAgent:
                     meta={"text": transcription},
                     latency=t_whisper - t_0,
                 )
-                if not transcription or len(audio_data) < 100:
+                if not transcription:
                     return
 
                 system_prompt = {
@@ -483,3 +505,9 @@ class ResponseAgent:
             audio=np.frombuffer(audio_chunk_bytes, dtype=np.int16),
             latency=t_styletts - t_normalize,
         )
+
+    def on_message(self, result):
+        transcript = result.channel.alternatives[0].transcript
+        if transcript:
+            self.transcript = transcript
+        print("DEEPGRAM TRANSCRIPT: ", self.transcript, flush=True)

--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -251,24 +251,25 @@ class ResponseAgent:
 
         self._time_of_last_record = None
 
-        self.dg_connection = deepgram.listen.live.v("1")
-        options = LiveOptions(
-            model="nova-2",
-            punctuate=True,
-            language="en-US",
-            encoding="linear16",
-            channels=1,
-            sample_rate=WS_SAMPLE_RATE,
-            interim_results=True,
-            utterance_end_ms="1000",
-            vad_events=True,
-        )
+        if ASR_METHOD == "deepgram":
+            self.dg_connection = deepgram.listen.live.v("1")
+            options = LiveOptions(
+                model="nova-2",
+                punctuate=True,
+                language="en-US",
+                encoding="linear16",
+                channels=1,
+                sample_rate=WS_SAMPLE_RATE,
+                interim_results=True,
+                utterance_end_ms="1000",
+                vad_events=True,
+            )
 
-        self.dg_connection.on(
-            LiveTranscriptionEvents.Transcript,
-            lambda x, result, **kwargs: self.on_message(result),
-        )
-        self.dg_connection.start(options)
+            self.dg_connection.on(
+                LiveTranscriptionEvents.Transcript,
+                lambda x, result, **kwargs: self.on_message(result),
+            )
+            self.dg_connection.start(options)
 
     def _reset_transcription(self):
         self.audio_data = []
@@ -505,7 +506,7 @@ class ResponseAgent:
             latency=t_styletts - t_normalize,
         )
 
-    def on_message(self, result):
+    def on_deepgram_message(self, result):
         transcript = result.channel.alternatives[0].transcript
         if transcript:
             self.transcript = transcript

--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -289,7 +289,8 @@ class ResponseAgent:
 
     async def receive_audio(self, message: bytes):
 
-        self.dg_connection.send(message)
+        if ASR_METHOD == "deepgram":
+            self.dg_connection.send(message)
 
         # Convert the input audio from input_audio_format to float32
         # Silero VAD and Whisper require float32

--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -259,7 +259,6 @@ class ResponseAgent:
             encoding="linear16",
             channels=1,
             sample_rate=WS_SAMPLE_RATE,
-            # To get UtteranceEnd, the following must be set:
             interim_results=True,
             utterance_end_ms="1000",
             vad_events=True,

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -219,7 +219,7 @@ async def connect_daily(
     voice_id=None,
     speak_first=False,
     context: Optional[Dict[str, str]] = None,
-    record=False,
+    record=True,
 ):
     session_id = str(uuid4())
     mic = Daily.create_microphone_device(
@@ -279,7 +279,7 @@ async def connect_daily(
         session_id=session_id,
         record=record,
         input_audio_format="int16",
-        tts_config=TTSConfig(provider="local", voice_id=voice_id),
+        tts_config=TTSConfig(provider="elevenlabs", voice_id=voice_id),
         system_prompt=system_prompt,
         context=base_context,
     )

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -219,7 +219,7 @@ async def connect_daily(
     voice_id=None,
     speak_first=False,
     context: Optional[Dict[str, str]] = None,
-    record=True,
+    record=False,
 ):
     session_id = str(uuid4())
     mic = Daily.create_microphone_device(
@@ -279,7 +279,7 @@ async def connect_daily(
         session_id=session_id,
         record=record,
         input_audio_format="int16",
-        tts_config=TTSConfig(provider="elevenlabs", voice_id=voice_id),
+        tts_config=TTSConfig(provider="local", voice_id=voice_id),
         system_prompt=system_prompt,
         context=base_context,
     )


### PR DESCRIPTION
## **User description**
attempting to be backwards compatible with whisper. 

when ASR_METHOD == "deepgram", deepgram keeps track of the transcription as it goes in `self.transcription`, which is used in start_response(). 

Next, I think deepgram has VAD functionality, so we can get rid of silero vad and call start_response() once deepgram has a transcript ready.


___

## **Description**
- Integrated Deepgram's live transcription service into the `ResponseAgent` class, replacing the previous static transcription setup.
- Added a new `transcript` attribute to `ResponseAgent` to store the ongoing transcription result from Deepgram.
- Set up event handling for live transcription results, updating the `transcript` attribute accordingly.
- Modified the `receive_audio` method to send audio data to Deepgram's live transcription service.
- Updated the `start_response` method to use the live transcription result when Deepgram is selected as the ASR method.
- Changed the default recording behavior in the `connect_daily` function to not record by default.
- Changed the TTS provider from ElevenLabs to local in the `connect_daily` function.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>response_agent.py</strong><dd><code>Integrate Deepgram Live Transcription</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openduck-py/openduck_py/response_agent.py
<li>Replaced <code>PrerecordedOptions</code> and <code>FileSource</code> with <br><code>LiveTranscriptionEvents</code> and <code>LiveOptions</code> for DeepgramClient.<br> <li> Initialized DeepgramClient outside of the conditional check for <br><code>ASR_METHOD</code>.<br> <li> Added live transcription setup with event handling for Deepgram.<br> <li> Removed commented-out initialization of SileroVad.<br> <li> Added a new <code>transcript</code> attribute to store ongoing transcription.<br> <li> Updated <code>receive_audio</code> method to send audio data to Deepgram live <br>transcription.<br> <li> Modified <code>start_response</code> to use the stored <code>transcript</code> when <code>ASR_METHOD</code> <br>is set to "deepgram".<br> <li> Added <code>on_message</code> method to handle live transcription events and update <br>the <code>transcript</code>.


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/101/files#diff-2a998d0b8029e572af7e5336e8b76fc6a8e411c591a2cb95768cf08dc6bb6f03">+41/-13</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>voice.py</strong><dd><code>Update Voice Router Configuration Defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openduck-py/openduck_py/routers/voice.py
<li>Changed the default value of <code>record</code> from <code>True</code> to <code>False</code> in <br><code>connect_daily</code> function.<br> <li> Updated the <code>TTSConfig</code> provider from "elevenlabs" to "local" in <br><code>connect_daily</code> function.


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/101/files#diff-83ea5947a09005723a4450b92f794118b9e55099439455d9d9b4152c3ff0c4ce">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
