### PR TITLE
speech prob and settings refactor

### DIFF
--- a/openduck-py/openduck_py/settings.py
+++ b/openduck-py/openduck_py/settings.py
@@ -1,27 +1,34 @@
 import os
 from typing import Literal
 
-HF_AUTH_TOKEN = os.environ.get("HF_AUTH_TOKEN")
-EMB_MATCH_THRESHOLD = 0.5
-WS_SAMPLE_RATE = 16_000
-OUTPUT_SAMPLE_RATE = 24_000
+# Env settings and secrets
 IS_DEV = bool(os.environ.get("IS_DEV"))
 ML_API_URL = os.environ["ML_API_URL"]
+LOG_TO_SLACK = bool(os.environ.get("LOG_TO_SLACK", False))
+AUDIO_UPLOAD_BUCKET = os.environ.get("AUDIO_UPLOAD_BUCKET", "openduck-us-west-2")
+HF_AUTH_TOKEN = os.environ.get("HF_AUTH_TOKEN")
+DEEPGRAM_API_SECRET = os.environ.get("DEEPGRAM_API_SECRET")
+
+# Audio settings
+WS_SAMPLE_RATE = 16_000
+OUTPUT_SAMPLE_RATE = 24_000
 # Set to 1024 for the esp32, but larger CHUNK_SIZE is needed to prevent choppiness with the local client
 CHUNK_SIZE = 10240
-LOG_TO_SLACK = bool(os.environ.get("LOG_TO_SLACK", False))
-TEMPERATURE = 1.2
 
+EMB_MATCH_THRESHOLD = 0.5
+LOG_TO_S3 = False
+NO_SPEECH_PROB_THRESHOLD = 0.8
+
+# LLM settings
 ChatModels = Literal[
     "azure/gpt-35-turbo-deployment", "azure/gpt-4-deployment", "groq/mixtral-8x7b-32768"
 ]
 CHAT_MODEL = "azure/gpt-35-turbo-deployment"
-AUDIO_UPLOAD_BUCKET = os.environ.get("AUDIO_UPLOAD_BUCKET", "openduck-us-west-2")
-LOG_TO_S3 = False
+TEMPERATURE = 1.2
 
+# ASR settings
 ASRMethod = Literal["deepgram", "whisper"]
 ASR_METHOD: ASRMethod = "whisper"
-DEEPGRAM_API_SECRET = os.environ.get("DEEPGRAM_API_SECRET")
 
 # to not break existing env files
 os.environ["AZURE_API_KEY"] = os.environ.get("AZURE_OPENAI_API_KEY", "")


### PR DESCRIPTION
## **User description**
Whisper outputs a `no_speech_prob`, which we can use to reduce false positives from VAD. If the `no_speech_prob` is above 0.8, we can cancel the response, because the audio is likely silence or background noise without speech from the user. 

Also organized the settings.py a bit.


___

## **Description**
- Implemented a new feature to reduce false positives in voice activity detection by using a `no_speech_prob` threshold.
- If the `no_speech_prob` from Whisper's transcription is above 0.8, the response is cancelled to avoid processing likely silence or noise.
- Reorganized `settings.py` to categorize different types of settings for better readability and maintenance.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ml.py</strong><dd><code>Implement no speech probability threshold check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openduck-py/openduck_py/routers/ml.py
<li>Added a check for <code>no_speech_prob</code> using a new threshold <br><code>NO_SPEECH_PROB_THRESHOLD</code> from settings.<br> <li> If <code>no_speech_prob</code> is greater than the threshold, the transcription is <br>set to an empty string.<br> <li> Imported <code>NO_SPEECH_PROB_THRESHOLD</code> from settings.


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/117/files#diff-4e910817ad08736f97b2a263f1bfffb939f1e4d58feee46bc929a2a0aabac554">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Add no speech probability threshold and reorganize settings</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openduck-py/openduck_py/settings.py
<li>Introduced <code>NO_SPEECH_PROB_THRESHOLD</code> with a value of 0.8.<br> <li> Reorganized environment and settings variables into categorized <br>sections.


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/117/files#diff-6f52d623d856f2aa53aab257c200162cfa0dcf7c8fd875f6f53f434bed4190de">+15/-8</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
