### PR TITLE
Interruptions changes

### DIFF
--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -424,17 +424,12 @@ class ResponseAgent:
         chat.history_json["messages"] = messages
         await db.commit()
 
-    async def start_response(self, transcription):
+    async def start_response(self, transcription: str):
         try:
             async with SessionAsync() as db:
                 t_0 = time()
 
                 print("TRANSCRIPTION: ", transcription, flush=True)
-
-                if transcription and self.is_responding:
-                    await log_event(db, self.session_id, "interrupted_response")
-                    await self.interrupt(self.response_task)
-
                 self.is_responding = True
 
                 t_asr = time()

--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -425,12 +425,12 @@ class ResponseAgent:
         await db.commit()
 
     async def start_response(self, transcription: str):
+        self.is_responding = True
         try:
             async with SessionAsync() as db:
                 t_0 = time()
 
                 print("TRANSCRIPTION: ", transcription, flush=True)
-                self.is_responding = True
 
                 t_asr = time()
                 await log_event(


### PR DESCRIPTION
## **User description**
There was a problem where the bot would suddenly stop talking because of interruption false positives. This was because VAD would detect start of speech on background noise, which interrupted the bot. Instead, we can interrupt only after VAD detects end of speech and whisper detects no_speech_prob < 0.5. This required moving whisper outside of start_response().

The new behavior is that the bot doesn't stop talking on interrupt until after Whisper processes the user's new speech. I think it would be helpful to have a clicking sound to signify when the bot hears the user or begins a new response, because now it's hard to tell when the bot switches to answering the new question. Also, the Whisper transcription quality seems to be worse when you're talking over the bot.


___

## **Description**
- The PR addresses an issue where the bot would prematurely stop talking due to false positives in speech detection.
- Now, the bot only interrupts its response after the user's speech has ended and the transcription has been processed, ensuring that interruptions are based on meaningful user input.
- This change improves the user experience by preventing unnecessary interruptions and maintaining the flow of conversation.
- Additionally, the PR cleans up the code by removing unnecessary transcription steps and optimizing event logging.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>response_agent.py</strong><dd><code>Refactor Response Interruption Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openduck-py/openduck_py/response_agent.py
<li>Refactored the response handling to interrupt only after a complete <br>user speech is detected and transcribed.<br> <li> Removed the previous behavior of interrupting the bot's response at <br>the start of user speech.<br> <li> Eliminated redundant transcription during the response initiation.<br> <li> Streamlined the event logging for speech detection and response <br>interruption.


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/124/files#diff-2a998d0b8029e572af7e5336e8b76fc6a8e411c591a2cb95768cf08dc6bb6f03">+25/-28</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
