### PR TITLE
Personas config and tts options

### DIFF
--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -496,9 +496,13 @@ class ResponseAgent:
                     response_text, voice_id=self.tts_config.voice_id
                 )
             elif self.tts_config.provider == "openai":
-                audio_bytes_iter = aio_openai_tts(response_text)
+                audio_bytes_iter = aio_openai_tts(
+                    response_text, voice=self.tts_config.voice_id
+                )
             elif self.tts_config.provider == "azure":
-                audio_bytes_iter = aio_azure_tts(response_text)
+                audio_bytes_iter = aio_azure_tts(
+                    response_text, voice_name=self.tts_config.voice_id
+                )
             elif self.tts_config.provider == "gptsovits":
                 audio_bytes_iter = aio_gptsovits_tts(
                     response_text, voice_ref=self.tts_config.voice_id

--- a/openduck-py/openduck_py/routers/voice.py
+++ b/openduck-py/openduck_py/routers/voice.py
@@ -313,8 +313,6 @@ async def connect_daily(
         record=record,
         input_audio_format="int16",
         tts_config=tts_config,
-        # tts_config=TTSConfig(provider="elevenlabs", voice_id=voice_id),
-        # tts_config=TTSConfig(provider="azure"),
         system_prompt=system_prompt,
         context=base_context,
     )


### PR DESCRIPTION
## **User description**
* Store personas in a dict
* Pass tts and prompt options to agent


___

## **Description**
- Implemented a new `personas` dictionary to manage different voice personas, each with its own TTS configuration and prompt.
- Updated TTS configuration handling to support different voice parameters for various providers in `response_agent.py`.
- Refactored `create_room_and_start`, `connect_daily`, and `run_connect_daily` functions in `routers/voice.py` to utilize the new `personas` configuration and `tts_config` parameter.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>response_agent.py</strong><dd><code>Enhance TTS Configuration for Multiple Providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openduck-py/openduck_py/response_agent.py
<li>Enhanced TTS configuration by passing <code>voice_id</code> as <code>voice</code> or <code>voice_name</code> <br>parameter based on the provider.


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/125/files#diff-2a998d0b8029e572af7e5336e8b76fc6a8e411c591a2cb95768cf08dc6bb6f03">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>voice.py</strong><dd><code>Implement Personas Configuration and TTS Options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openduck-py/openduck_py/routers/voice.py
<li>Added a <code>personas</code> dictionary to store configurations for different <br>personas.<br> <li> Updated <code>create_room_and_start</code> to use <code>personas</code> config for setting up <br>voice and prompt options.<br> <li> Modified <code>connect_daily</code> and <code>run_connect_daily</code> functions to accept <br><code>tts_config</code> instead of <code>voice_id</code>.


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/125/files#diff-83ea5947a09005723a4450b92f794118b9e55099439455d9d9b4152c3ff0c4ce">+36/-10</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details><summary><strong>🔍 Anti-patterns Detected:</strong></summary><hr>
<details><summary><strong>openduck-py/openduck_py/routers/voice.py</strong></summary><div><table><tr><th>Issue</th><th>Lines</th></tr><tr><td>Consider using '{"room_url": room_info['url'], "username": personas[request.prompt]['username'], ... }' instead of a call to 'dict'.</td><td><a href='https://github.com/uberduck-ai/openduck/blob/will-voice-config/openduck-py/openduck_py/routers/voice.py#L151:L162' target='_blank'>151-162</a></td></tr></table></div></details></details><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
