### PR TITLE
fix interrupts

### DIFF
--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -332,21 +332,9 @@ class ResponseAgent:
                         if "start" in vad_result:
                             self.speech_has_started = True
                             print("Detected start of speech", flush=True)
-                            # await log_event(
-                            #     db,
-                            #     self.session_id,
-                            #     "detected_start_of_speech",
-                            #     audio=audio_data,
-                            # )
                         else:
                             self.speech_has_started = False
                             print("Detected end of speech", flush=True)
-                            # await log_event(
-                            #     db,
-                            #     self.session_id,
-                            #     "detected_end_of_speech",
-                            #     audio=audio_data,
-                            # )
 
                         if self.speech_has_started:
                             self.audio_data.append(audio_16k_np)

--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -243,6 +243,7 @@ class ResponseAgent:
         self.response_task: Optional[asyncio.Task] = None
         self.interrupt_event = asyncio.Event()
         self.system_prompt = system_prompt
+        self.speech_has_started = False
 
         if context is None:
             context = {}
@@ -325,10 +326,30 @@ class ResponseAgent:
             vad_result = self.vad(audio_16k_chunk)
             if vad_result:
                 async with SessionAsync() as db:
-                    if "end" in vad_result:
-                        print("end of speech detected.")
+                    transcription = ""
+                    if "start" in vad_result or "end" in vad_result:
                         self.time_of_last_activity = time()
-                        await log_event(db, self.session_id, "detected_end_of_speech")
+                        if "start" in vad_result:
+                            self.speech_has_started = True
+                            print("Detected start of speech", flush=True)
+                            # await log_event(
+                            #     db,
+                            #     self.session_id,
+                            #     "detected_start_of_speech",
+                            #     audio=audio_data,
+                            # )
+                        else:
+                            self.speech_has_started = False
+                            print("Detected end of speech", flush=True)
+                            # await log_event(
+                            #     db,
+                            #     self.session_id,
+                            #     "detected_end_of_speech",
+                            #     audio=audio_data,
+                            # )
+
+                        if self.speech_has_started:
+                            self.audio_data.append(audio_16k_np)
 
                         audio_data = np.concatenate(self.audio_data)
                         transcription = await _transcribe(audio_data)

--- a/openduck-py/openduck_py/response_agent.py
+++ b/openduck-py/openduck_py/response_agent.py
@@ -353,17 +353,16 @@ class ResponseAgent:
                             await log_event(db, self.session_id, "interrupted_response")
                             await self.interrupt(self.response_task)
 
-                        await log_event(
-                            db, self.session_id, "started_response", audio=audio_data
-                        )
-                        self.response_task = asyncio.create_task(
-                            self.start_response(transcription)
-                        )
-
-                    if "start" in vad_result:
-                        print("start of speech detected.")
-                        self.time_of_last_activity = time()
-                        await log_event(db, self.session_id, "detected_start_of_speech")
+                        if "end" in vad_result:
+                            await log_event(
+                                db,
+                                self.session_id,
+                                "started_response",
+                                audio=audio_data,
+                            )
+                            self.response_task = asyncio.create_task(
+                                self.start_response(transcription)
+                            )
             i = upper
 
     async def _generate_and_speak(


### PR DESCRIPTION
## **User description**
The previous PR caused problems because it no longer interrupted the bot after start of speech was detected by VAD. This changes it to allow interruptions after start_of_speech is detected, if whisper detects no_speech_prob < 0.5.

Also, we only append to self.audio_data if start of speech has been detected. This should help with the spurious "Thank yous" that whisper hears on silence. 

___

## **Description**
- Introduced a state tracking mechanism with `self.speech_has_started` to determine if the speech has started, which prevents appending audio data until speech is detected.
- Removed logging for 'detected_start_of_speech' and 'detected_end_of_speech' events to streamline the audio handling process.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>response_agent.py</strong><dd><code>Implement Speech Start Detection for Audio Data Appending</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openduck-py/openduck_py/response_agent.py
<li>Added a new boolean attribute <code>self.speech_has_started</code> to track the <br>start of speech.<br> <li> Modified <code>receive_audio</code> method to only append audio data if speech has <br>started.<br> <li> Removed unnecessary logging of start and end of speech events.


</details>
    

  </td>
  <td><a href="https://github.com/uberduck-ai/openduck/pull/127/files#diff-2a998d0b8029e572af7e5336e8b76fc6a8e411c591a2cb95768cf08dc6bb6f03">+7/-16</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
